### PR TITLE
Add simple OutCycling website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # MockOutcyclingWebsite
+
+This repository contains a simple static website for the OutCycling biking club.
+
+## GitHub Pages
+The site is ready to be served via [GitHub Pages](https://pages.github.com/). To publish:
+1. In your repository settings, enable **GitHub Pages**.
+2. For the **Source**, select the `docs` folder on the `main` branch.
+3. Save. GitHub will build and deploy the site at `https://<username>.github.io/<repository>/`.
+
+The rendered site entry point is `docs/index.html` and it references assets using relative paths, so it will work from the published URL.
+
+## Local preview
+Open `docs/index.html` in your browser to view the site locally.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OutCycling</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-content">
+      <h1>OutCycling</h1>
+      <p>Join us for fun and inclusive rides!</p>
+      <a href="#join" class="cta-button">Come ride with us</a>
+    </div>
+  </header>
+
+  <nav class="main-nav">
+    <ul>
+      <li><a href="#join">Join the Club</a></li>
+      <li><a href="#about">About Us</a></li>
+      <li><a href="#calendar">Calendar of Events</a></li>
+      <li><a href="#captains">Meet Your Ride Captains</a></li>
+      <li><a href="#donate">Donate</a></li>
+    </ul>
+  </nav>
+
+  <section id="join" class="content-section">
+    <h2>Join the Club</h2>
+    <p>Become part of a welcoming community of cyclists. All skill levels are welcome!</p>
+  </section>
+
+  <section id="about" class="content-section">
+    <h2>About Us</h2>
+    <p>OutCycling is a biking club dedicated to promoting health, friendship, and fun through group rides and events.</p>
+  </section>
+
+  <section id="calendar" class="content-section">
+    <h2>Calendar of Events</h2>
+    <ul>
+      <li>April 20 - Central Park Loop</li>
+      <li>May 5 - Hudson River Ride</li>
+      <li>June 10 - Pride Ride</li>
+    </ul>
+  </section>
+
+  <section id="captains" class="content-section">
+    <h2>Meet Your Ride Captains</h2>
+    <p>Our ride captains are experienced cyclists who help ensure safe and enjoyable rides.</p>
+  </section>
+
+  <section id="donate" class="content-section">
+    <h2>Donate</h2>
+    <p>Your contributions help us organize more events and support our community.</p>
+    <button class="donate-button">Donate Now</button>
+  </section>
+
+  <footer>
+    <p>&copy; 2024 OutCycling</p>
+  </footer>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,93 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+}
+
+.hero {
+  background: url('https://images.unsplash.com/photo-1525113991271-3a3d4e226537?auto=format&fit=crop&w=1650&q=80') center/cover no-repeat;
+  height: 100vh;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.hero-content h1 {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+.cta-button {
+  display: inline-block;
+  padding: 1rem 2rem;
+  margin-top: 1rem;
+  background-color: #ff6600;
+  color: #fff;
+  text-decoration: none;
+  font-size: 1.25rem;
+  border-radius: 5px;
+}
+
+.main-nav {
+  background: #333;
+}
+
+.main-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.main-nav li {
+  margin: 0.5rem;
+}
+
+.main-nav a {
+  color: #fff;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+}
+
+.content-section {
+  padding: 2rem;
+}
+
+.content-section:nth-of-type(even) {
+  background: #f4f4f4;
+}
+
+.donate-button {
+  padding: 0.75rem 1.5rem;
+  background: #0077cc;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #333;
+  color: #fff;
+}
+
+@media (max-width: 600px) {
+  .hero-content h1 {
+    font-size: 2rem;
+  }
+
+  .cta-button {
+    font-size: 1rem;
+    padding: 0.75rem 1.5rem;
+  }
+
+  .main-nav ul {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- Move site into `docs/` with `.nojekyll` for GitHub Pages hosting
- Include hero, navigation, and club sections in `index.html`
- Document Pages setup in README

## Testing
- `npx --yes html-validate docs/index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-validate)*
- `npm test` *(fails: ENOENT: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a1d622648321b8b83353650b0ca2