### PR TITLE
Add second mock with ride calendar and Pride Ride pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
   <h1>Available Mocks</h1>
   <ul>
     <li><a href="mock1/">Mock 1</a></li>
+    <li><a href="mock2/">Mock 2</a></li>
   </ul>
 </body>
 </html>

--- a/docs/mock2/calendar.html
+++ b/docs/mock2/calendar.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OutCycling — Ride Calendar</title>
+  <meta name="description" content="Search for upcoming rides, sign up, and download routes." />
+  <link rel="icon" href="../media/hero.jpg" />
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="index.html#top" aria-label="OutCycling home">
+        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-text">OutCycling</span>
+      </a>
+
+      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
+        <span class="sr-only">Toggle navigation</span>
+        ☰
+      </button>
+
+      <nav id="site-nav" class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="join.html">Join</a></li>
+          <li><a href="calendar.html">Calendar</a></li>
+          <li><a href="organize.html">Organize</a></li>
+          <li><a href="pride-ride.html">Pride Ride</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Upcoming Rides</h2>
+          <p>Search and sign up for rides.</p>
+          <form class="ride-search" role="search">
+            <label class="sr-only" for="ride-search">Search rides</label>
+            <input id="ride-search" type="search" placeholder="Distance, location, pace..." />
+          </form>
+        </div>
+
+        <div class="table-wrap">
+          <table class="events">
+            <thead>
+              <tr><th>Date</th><th>Ride</th><th>Distance</th><th>Meetup</th><th>Type</th><th>Actions</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Aug 24</td>
+                <td>Hudson River Greenway Social</td>
+                <td>18 mi / 29 km</td>
+                <td>Pier 25, 9:00 AM</td>
+                <td><span class="badge">OC</span></td>
+                <td>
+                  <a class="btn btn-small" href="#">Sign up</a>
+                  <a class="btn btn-small" href="#">Ask</a>
+                  <a class="btn btn-small" href="#">Route</a>
+                  <a class="btn btn-small" href="#">GPX</a>
+                </td>
+              </tr>
+              <tr>
+                <td>Sep 7</td>
+                <td>Intro to Group Riding</td>
+                <td>12 mi / 19 km</td>
+                <td>Prospect Park, 10:00 AM</td>
+                <td><span class="badge badge-third">3P</span></td>
+                <td>
+                  <a class="btn btn-small" href="#">Sign up</a>
+                  <a class="btn btn-small" href="#">Ask</a>
+                  <a class="btn btn-small" href="#">Route</a>
+                  <a class="btn btn-small" href="#">GPX</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="muted small">Routes via RideWithGPS. Slack invites are sent automatically when you sign up.</p>
+        <figure class="route-preview">
+          <img src="https://placehold.co/600x300?text=Route+Preview" alt="Route preview placeholder" />
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>© <span id="year"></span> OutCycling</p>
+      <p class="small muted">Made with ❤️ and human power.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/mock2/index.html
+++ b/docs/mock2/index.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OutCycling — Come ride with us</title>
+  <meta name="description" content="OutCycling is a friendly biking club. Come ride with us! Join, learn about us, see rides, and get involved." />
+  <meta property="og:title" content="OutCycling — Come ride with us" />
+  <meta property="og:description" content="Group rides, community, and fun on two wheels." />
+  <meta property="og:image" content="../media/hero.jpg" />
+  <link rel="icon" href="../media/hero.jpg" />
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="#top" aria-label="OutCycling home">
+        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-text">OutCycling</span>
+      </a>
+
+      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
+        <span class="sr-only">Toggle navigation</span>
+        ☰
+      </button>
+
+      <nav id="site-nav" class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="join.html">Join</a></li>
+          <li><a href="calendar.html">Calendar</a></li>
+          <li><a href="organize.html">Organize</a></li>
+          <li><a href="pride-ride.html">Pride Ride</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero" role="banner" aria-label="OutCycling hero">
+      <div class="overlay">
+        <div class="hero-content container">
+          <h1>Rides, community, and a lot of fun.</h1>
+          <p>All speeds, all distances, all are welcome.</p>
+          <a class="btn btn-primary btn-lg" href="join.html" aria-label="Come ride with us — join page">
+            Come ride with us
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <section id="about" class="section section-alt">
+      <div class="container">
+        <div class="grid-2 about-grid">
+          <div>
+            <h2>About us</h2>
+            <p>OutCycling is a community-focused cycling club dedicated to safe, inclusive rides for all levels. We organize weekly rides, skills clinics, and social events. Helmets required, smiles encouraged.</p>
+            <ul class="checklist">
+              <li>No-drop rides for beginners</li>
+              <li>Speed groups for intermediate & advanced</li>
+              <li>Volunteer-led, community powered</li>
+            </ul>
+          </div>
+          <figure class="about-photo">
+            <img src="../media/about.jpg" alt="A happy group of OutCycling riders gathering before a ride" />
+            <figcaption>Good vibes before wheels roll.</figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section id="subscribe" class="section">
+      <div class="container">
+        <h2>Stay in the loop</h2>
+        <p>Get ride updates and club news.</p>
+        <form class="ride-form">
+          <label for="email">Email</label>
+          <input id="email" type="email" placeholder="you@example.com" />
+          <button class="btn btn-primary" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </section>
+
+    <section id="calendar" class="section section-alt">
+      <div class="container">
+        <h2>Upcoming rides</h2>
+        <p>Here are a few highlights. <a href="calendar.html">View full calendar</a>.</p>
+        <div class="table-wrap">
+          <table class="events">
+            <thead>
+              <tr><th>Date</th><th>Event</th><th>Distance</th><th>Meetup</th><th></th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Aug 24</td>
+                <td>Hudson River Greenway Social</td>
+                <td>18 mi / 29 km</td>
+                <td>Pier 25, 9:00 AM</td>
+                <td><a class="btn btn-small" href="calendar.html">Details</a></td>
+              </tr>
+              <tr>
+                <td>Sep 7</td>
+                <td>Intro to Group Riding</td>
+                <td>12 mi / 19 km</td>
+                <td>Prospect Park, 10:00 AM</td>
+                <td><a class="btn btn-small" href="calendar.html">Details</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section id="pride" class="section">
+      <div class="container">
+        <div class="grid-2 about-grid">
+          <div>
+            <h2>Pride Ride</h2>
+            <p>Celebrate with us in our annual Pride Ride. Choose a distance and ride with friends.</p>
+            <a class="btn btn-primary" href="pride-ride.html">Learn more</a>
+          </div>
+          <figure class="about-photo">
+            <img src="https://placehold.co/400x250?text=Pride+Ride" alt="Pride Ride placeholder" />
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section id="captains" class="section section-alt">
+      <div class="container">
+        <h2>Meet your ride captains</h2>
+        <div class="cards grid-3 captains-grid">
+          <article class="card person">
+            <img src="../media/captain-george.jpg" alt="George D., OutCycling ride captain" loading="lazy" />
+            <h3>George D.</h3>
+            <p class="muted">No-drop & Skills</p>
+            <p>Loves introducing new riders to group riding and bike handling.</p>
+          </article>
+          <article class="card person">
+            <img src="../media/captain-delta.jpg" alt="Delta C., OutCycling ride captain" loading="lazy" />
+            <h3>Delta C.</h3>
+            <p class="muted">Endurance & Routes</p>
+            <p>Route geek. Knows every scenic detour and the best coffee stops.</p>
+          </article>
+          <article class="card person">
+            <img src="../media/captain-johnny.jpg" alt="Johnny C., OutCycling ride captain" loading="lazy" />
+            <h3>Johnny C.</h3>
+            <p class="muted">Safety & Pacing</p>
+            <p>Calm, patient, and laser-focused on safe, steady group pace lines.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="donate" class="section">
+      <div class="container donate-cta">
+        <div>
+          <h2>Support the mission</h2>
+          <p>Your donation helps us run clinics, maintain routes, and expand access to cycling.</p>
+        </div>
+        <a class="btn btn-primary btn-lg" href="#" aria-label="Donate to OutCycling">Donate</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>© <span id="year"></span> OutCycling</p>
+      <p class="small muted">Made with ❤️ and human power.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/mock2/join.html
+++ b/docs/mock2/join.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OutCycling — Join the club</title>
+  <meta name="description" content="OutCycling membership levels: Starter, Rider, and Supporter." />
+  <link rel="icon" href="../media/hero.jpg" />
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="index.html#top" aria-label="OutCycling home">
+        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-text">OutCycling</span>
+      </a>
+
+      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
+        <span class="sr-only">Toggle navigation</span>
+        ☰
+      </button>
+
+      <nav id="site-nav" class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="join.html">Join</a></li>
+          <li><a href="calendar.html">Calendar</a></li>
+          <li><a href="organize.html">Organize</a></li>
+          <li><a href="pride-ride.html">Pride Ride</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section id="join" class="section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Join the club</h2>
+          <p>Membership gets you access to group rides, skills clinics, and a welcoming community.</p>
+        </div>
+        <div class="cards grid-3">
+          <article class="card">
+            <h3>Starter</h3>
+            <p class="price">$0 / month</p>
+            <ul>
+              <li>1 intro ride</li>
+              <li>Newsletter & updates</li>
+            </ul>
+            <a class="btn btn-outline" href="#" aria-label="Select Starter plan">Get started</a>
+          </article>
+          <article class="card featured">
+            <h3>Rider</h3>
+            <p class="price">$8 / month</p>
+            <ul>
+              <li>Unlimited group rides</li>
+              <li>Members chat & forums</li>
+              <li>Discounts with partners</li>
+            </ul>
+            <a class="btn btn-primary" href="#" aria-label="Select Rider plan">Join now</a>
+          </article>
+          <article class="card">
+            <h3>Supporter</h3>
+            <p class="price">$15 / month</p>
+            <ul>
+              <li>Everything in Rider</li>
+              <li>Support youth programs</li>
+            </ul>
+            <a class="btn btn-outline" href="#" aria-label="Select Supporter plan">Become a supporter</a>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>© <span id="year"></span> OutCycling</p>
+      <p class="small muted">Made with ❤️ and human power.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/mock2/organize.html
+++ b/docs/mock2/organize.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OutCycling — Organize a Ride</title>
+  <meta name="description" content="Schedule and manage rides for the OutCycling community." />
+  <link rel="icon" href="../media/hero.jpg" />
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="index.html#top" aria-label="OutCycling home">
+        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-text">OutCycling</span>
+      </a>
+
+      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
+        <span class="sr-only">Toggle navigation</span>
+        ☰
+      </button>
+
+      <nav id="site-nav" class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="join.html">Join</a></li>
+          <li><a href="calendar.html">Calendar</a></li>
+          <li><a href="organize.html">Organize</a></li>
+          <li><a href="pride-ride.html">Pride Ride</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Schedule a Ride</h2>
+          <p>Ride captains can schedule and manage rides here.</p>
+        </div>
+        <form class="ride-form">
+          <label for="ride-title">Ride title</label>
+          <input id="ride-title" type="text" placeholder="Sunset Loop" />
+
+          <label for="ride-date">Date</label>
+          <input id="ride-date" type="date" />
+
+          <label for="ride-distance">Distance</label>
+          <input id="ride-distance" type="text" placeholder="25 mi" />
+
+          <label for="ride-tier">Visibility</label>
+          <select id="ride-tier">
+            <option>All members</option>
+            <option>Rider tier+</option>
+          </select>
+
+          <button class="btn btn-primary" type="submit">Publish</button>
+        </form>
+        <p class="muted small">Manage recurring rides, respond to questions, and send updates to participants.</p>
+        <figure class="route-preview">
+          <img src="https://placehold.co/600x300?text=Extra-pay+Ride+Photo" alt="Placeholder for extra-pay ride" />
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>© <span id="year"></span> OutCycling</p>
+      <p class="small muted">Made with ❤️ and human power.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/mock2/pride-ride.html
+++ b/docs/mock2/pride-ride.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OutCycling — Pride Ride</title>
+  <meta name="description" content="Learn about the Pride Ride and sign up to participate." />
+  <link rel="icon" href="../media/hero.jpg" />
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="index.html#top" aria-label="OutCycling home">
+        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-text">OutCycling</span>
+      </a>
+
+      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
+        <span class="sr-only">Toggle navigation</span>
+        ☰
+      </button>
+
+      <nav id="site-nav" class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="join.html">Join</a></li>
+          <li><a href="calendar.html">Calendar</a></li>
+          <li><a href="organize.html">Organize</a></li>
+          <li><a href="pride-ride.html">Pride Ride</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <h2>Pride Ride</h2>
+        <p>Our annual celebration of cycling and Pride. Riders of all levels are welcome.</p>
+        <figure class="route-preview">
+          <img src="https://placehold.co/600x300?text=Pride+Ride" alt="Pride Ride placeholder image" />
+        </figure>
+        <p>Sign up and secure your spot:</p>
+        <form class="ride-form">
+          <label for="pride-name">Name</label>
+          <input id="pride-name" type="text" />
+          <label for="pride-email">Email</label>
+          <input id="pride-email" type="email" />
+          <label for="pride-distance">Distance</label>
+          <select id="pride-distance">
+            <option>20 mi</option>
+            <option>40 mi</option>
+            <option>60 mi</option>
+          </select>
+          <button class="btn btn-primary" type="submit">Register & Pay</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>© <span id="year"></span> OutCycling</p>
+      <p class="small muted">Made with ❤️ and human power.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/mock2/script.js
+++ b/docs/mock2/script.js
@@ -1,0 +1,20 @@
+// Mobile nav toggle
+const toggle = document.querySelector('.nav-toggle');
+const nav = document.querySelector('#site-nav');
+if (toggle && nav) {
+  toggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  });
+}
+
+// Close nav when a link is clicked (on mobile)
+nav?.querySelectorAll('a').forEach(a => {
+  a.addEventListener('click', () => {
+    nav.classList.remove('open');
+    toggle?.setAttribute('aria-expanded', 'false');
+  });
+});
+
+// Current year in footer
+document.getElementById('year').textContent = new Date().getFullYear();

--- a/docs/mock2/styles.css
+++ b/docs/mock2/styles.css
@@ -1,0 +1,185 @@
+:root{
+  --bg: #0b0b0c;
+  --bg-alt: #111216;
+  --surface: #17181d;
+  --text: #e9ecf1;
+  --muted: #a9b0bc;
+  --primary: #3ecf8e;
+  --primary-ink: #09281a;
+  --ring: rgba(62,207,142,.5);
+  --maxw: 1100px;
+  --radius: 14px;
+  --shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; scroll-behavior: smooth; }
+body{
+  margin:0;
+  font: 16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif;
+  color: var(--text);
+  background: linear-gradient(180deg, #0a0b0d 0%, #0d0f13 100%);
+}
+
+.container{
+  width: min(100% - 2rem, var(--maxw));
+  margin-inline: auto;
+}
+
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1,h2,h3{ line-height: 1.2; margin: 0 0 .5rem }
+h1{ font-size: clamp(2rem, 3vw + 1rem, 3rem); }
+h2{ font-size: clamp(1.5rem, 1.5vw + 1rem, 2rem); }
+h3{ font-size: 1.15rem; }
+p{ margin: 0 0 1rem; }
+.small{ font-size:.9rem; }
+.muted{ color: var(--muted); }
+
+/* Header */
+.site-header{
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(10, 12, 16, .8); backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(255,255,255,.06);
+}
+.header-inner{
+  display:flex; align-items:center; gap:1rem; padding: .8rem 0;
+}
+.brand{ display:flex; align-items:center; gap:.6rem; font-weight: 700; color: var(--text); }
+.brand-mark{ font-size:1.25rem; }
+.brand-text{ letter-spacing:.2px; }
+
+.site-nav ul{ list-style:none; display:flex; gap:1rem; margin:0; padding:0; }
+.site-nav a{ padding:.5rem .7rem; border-radius: 8px; }
+.site-nav a:hover, .site-nav a:focus{ background: rgba(255,255,255,.06); text-decoration:none; }
+
+.nav-toggle{ display:none; border:0; background:transparent; color:var(--text); font-size:1.5rem; padding:.4rem .6rem; border-radius:10px; }
+.nav-toggle:focus{ outline: 2px solid var(--ring); outline-offset: 3px; }
+
+/* Hero */
+.hero{
+  min-height: 70vh;
+  background: url('../media/hero.jpg') center/cover no-repeat;
+  position: relative;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.hero .overlay{
+  position:absolute; inset:0;
+  background: linear-gradient(180deg, rgba(0,0,0,.55), rgba(0,0,0,.65));
+  display:grid; place-items:center;
+  text-align:center;
+}
+.hero-content{ padding: 6rem 0; }
+.hero p{ color: var(--muted); font-size: 1.1rem; }
+.btn{ display:inline-block; padding:.75rem 1rem; border-radius: 999px; border:1px solid rgba(255,255,255,.12); font-weight:600; }
+.btn:hover{ text-decoration:none; transform: translateY(-1px); }
+.btn:focus{ outline: 3px solid var(--ring); outline-offset: 2px; }
+.btn-primary{ background: var(--primary); color: var(--primary-ink); border-color: transparent; box-shadow: var(--shadow); }
+.btn-outline{ background: transparent; color: var(--text); }
+.btn-lg{ font-size: 1.05rem; padding: .9rem 1.2rem; }
+.btn-small{ font-size: .9rem; padding: .45rem .7rem; }
+
+/* Sections */
+.section{ padding: clamp(3rem, 6vw, 5rem) 0; }
+.section-alt{ background: radial-gradient(1200px 800px at 50% -10%, rgba(62,207,142,.08), transparent 60%), var(--bg-alt); }
+
+/* Grids & Cards */
+.grid-2{ display:grid; grid-template-columns: 1.2fr 1fr; gap:2rem; }
+.grid-3{ display:grid; grid-template-columns: repeat(3,1fr); gap:1.25rem; }
+.cards .card{
+  background: var(--surface); border:1px solid rgba(255,255,255,.06);
+  border-radius: var(--radius); padding: 1.2rem; box-shadow: var(--shadow);
+}
+.cards .card.featured{ outline: 2px solid var(--primary); }
+.cards .price{ font: 700 1.15rem/1 system-ui; margin:.2rem 0 1rem; }
+
+.checklist{ padding-left:1.2rem; }
+.checklist li{ margin:.3rem 0; }
+
+/* About */
+.about-photo img{ width:100%; border-radius: 12px; border:1px solid rgba(255,255,255,.08); display:block; }
+
+/* Calendar table */
+.table-wrap{ overflow-x:auto; border-radius: 12px; border:1px solid rgba(255,255,255,.08); }
+table.events{
+  width:100%; border-collapse: collapse; background: var(--surface);
+}
+.events th, .events td{ padding:.9rem .8rem; text-align:left; }
+.events thead th{
+  font-size:.9rem; color:var(--muted); border-bottom:1px solid rgba(255,255,255,.08);
+}
+.events tbody tr + tr td{ border-top:1px solid rgba(255,255,255,.06); }
+
+/* Captains */
+.person img{ width:100%; height: 220px; object-fit: cover; border-radius: 10px; margin-bottom:.7rem; }
+
+/* Donate */
+.donate-cta{
+  display:flex; align-items:center; justify-content:space-between; gap:1rem;
+  background: linear-gradient(135deg, rgba(62,207,142,.15), rgba(62,207,142,.05));
+  border:1px solid rgba(62,207,142,.35); border-radius: var(--radius); padding:1.2rem 1.2rem;
+}
+
+/* Footer */
+.site-footer{ padding: 2rem 0; border-top:1px solid rgba(255,255,255,.08); background: #0a0b0d; }
+.footer-inner{ display:flex; align-items:center; justify-content:space-between; }
+
+/* Skip link */
+.skip-link{
+  position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden;
+}
+.skip-link:focus{
+  left: 1rem; top: 1rem; width:auto; height:auto; padding:.5rem .7rem; background: var(--primary); color: var(--primary-ink); border-radius: 8px;
+}
+
+/* Responsive */
+@media (max-width: 900px){
+  .grid-2{ grid-template-columns: 1fr; }
+  .grid-3{ grid-template-columns: 1fr 1fr; }
+  .donate-cta{ flex-direction: column; align-items: flex-start; }
+}
+@media (max-width: 680px){
+  .grid-3{ grid-template-columns: 1fr; }
+  .site-nav{ display:none; position:absolute; right:1rem; top:64px; background: var(--surface); padding:.5rem; border-radius: 10px; border:1px solid rgba(255,255,255,.08); box-shadow: var(--shadow); }
+  .site-nav.open{ display:block; }
+  .site-nav ul{ flex-direction: column; }
+  .nav-toggle{ display:block; }
+}
+/* Badges */
+.badge{
+  display:inline-block;
+  padding:.2rem .4rem;
+  border-radius:6px;
+  font-size:.75rem;
+  background:var(--primary);
+  color:var(--primary-ink);
+}
+.badge-third{
+  background:rgba(255,255,255,.2);
+  color:var(--text);
+}
+
+/* Forms */
+.ride-search input,
+.ride-form input,
+.ride-form select{
+  padding:.5rem;
+  border-radius:8px;
+  border:1px solid rgba(255,255,255,.15);
+  background:var(--surface);
+  color:var(--text);
+  margin-right:.5rem;
+}
+.ride-form{
+  display:flex;
+  flex-direction:column;
+  gap:.6rem;
+  max-width:400px;
+}
+.route-preview img{
+  width:100%;
+  border-radius:12px;
+  margin-top:1rem;
+  border:1px solid rgba(255,255,255,.08);
+}


### PR DESCRIPTION
## Summary
- add new `mock2` prototype with navigation for join, calendar, organizing, and Pride Ride
- implement ride calendar with search, ride badges, and route preview placeholders
- add organizer scheduling form and Pride Ride registration page
- link new mock in docs index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ba007434832196f92a5b6ab8fcd1