### PR TITLE
feat: brighten mock2 with pride colors

### DIFF
--- a/docs/mock2/calendar.html
+++ b/docs/mock2/calendar.html
@@ -15,7 +15,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="index.html#top" aria-label="OutCycling home">
-        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-mark" aria-hidden="true">🚲🏳️‍🌈</span>
         <span class="brand-text">OutCycling</span>
       </a>
 

--- a/docs/mock2/index.html
+++ b/docs/mock2/index.html
@@ -18,7 +18,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="#top" aria-label="OutCycling home">
-        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-mark" aria-hidden="true">🚲🏳️‍🌈</span>
         <span class="brand-text">OutCycling</span>
       </a>
 
@@ -43,7 +43,7 @@
       <div class="overlay">
         <div class="hero-content container">
           <h1>Rides, community, and a lot of fun.</h1>
-          <p>All speeds, all distances, all are welcome.</p>
+          <p>All speeds, all distances, all identities are welcome. 🏳️‍🌈</p>
           <a class="btn btn-primary btn-lg" href="join.html" aria-label="Come ride with us — join page">
             Come ride with us
           </a>

--- a/docs/mock2/join.html
+++ b/docs/mock2/join.html
@@ -15,7 +15,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="index.html#top" aria-label="OutCycling home">
-        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-mark" aria-hidden="true">🚲🏳️‍🌈</span>
         <span class="brand-text">OutCycling</span>
       </a>
 

--- a/docs/mock2/organize.html
+++ b/docs/mock2/organize.html
@@ -15,7 +15,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="index.html#top" aria-label="OutCycling home">
-        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-mark" aria-hidden="true">🚲🏳️‍🌈</span>
         <span class="brand-text">OutCycling</span>
       </a>
 

--- a/docs/mock2/pride-ride.html
+++ b/docs/mock2/pride-ride.html
@@ -15,7 +15,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="index.html#top" aria-label="OutCycling home">
-        <span class="brand-mark" aria-hidden="true">🚲</span>
+        <span class="brand-mark" aria-hidden="true">🚲🏳️‍🌈</span>
         <span class="brand-text">OutCycling</span>
       </a>
 

--- a/docs/mock2/styles.css
+++ b/docs/mock2/styles.css
@@ -1,15 +1,15 @@
 :root{
-  --bg: #0b0b0c;
-  --bg-alt: #111216;
-  --surface: #17181d;
-  --text: #e9ecf1;
-  --muted: #a9b0bc;
-  --primary: #3ecf8e;
-  --primary-ink: #09281a;
-  --ring: rgba(62,207,142,.5);
+  --bg: #ffffff;
+  --bg-alt: #f7f7f7;
+  --surface: #ffffff;
+  --text: #1a1a1a;
+  --muted: #555555;
+  --primary: #ff69b4;
+  --primary-ink: #ffffff;
+  --ring: rgba(255,105,180,.5);
   --maxw: 1100px;
   --radius: 14px;
-  --shadow: 0 10px 30px rgba(0,0,0,.35);
+  --shadow: 0 10px 30px rgba(0,0,0,.15);
 }
 
 * { box-sizing: border-box; }
@@ -18,7 +18,7 @@ body{
   margin:0;
   font: 16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif;
   color: var(--text);
-  background: linear-gradient(180deg, #0a0b0d 0%, #0d0f13 100%);
+  background: linear-gradient(90deg, #ffdde1 0%, #ee9ca7 100%);
 }
 
 .container{
@@ -40,8 +40,9 @@ p{ margin: 0 0 1rem; }
 /* Header */
 .site-header{
   position: sticky; top: 0; z-index: 50;
-  background: rgba(10, 12, 16, .8); backdrop-filter: blur(8px);
-  border-bottom: 1px solid rgba(255,255,255,.06);
+  background: rgba(255,255,255,.8); backdrop-filter: blur(8px);
+  border-bottom:4px solid;
+  border-image: linear-gradient(90deg,#ff0000,#ff9900,#ffff00,#00ff00,#0000ff,#8b00ff) 1;
 }
 .header-inner{
   display:flex; align-items:center; gap:1rem; padding: .8rem 0;
@@ -52,7 +53,7 @@ p{ margin: 0 0 1rem; }
 
 .site-nav ul{ list-style:none; display:flex; gap:1rem; margin:0; padding:0; }
 .site-nav a{ padding:.5rem .7rem; border-radius: 8px; }
-.site-nav a:hover, .site-nav a:focus{ background: rgba(255,255,255,.06); text-decoration:none; }
+.site-nav a:hover, .site-nav a:focus{ background: rgba(0,0,0,.06); text-decoration:none; }
 
 .nav-toggle{ display:none; border:0; background:transparent; color:var(--text); font-size:1.5rem; padding:.4rem .6rem; border-radius:10px; }
 .nav-toggle:focus{ outline: 2px solid var(--ring); outline-offset: 3px; }
@@ -62,17 +63,17 @@ p{ margin: 0 0 1rem; }
   min-height: 70vh;
   background: url('../media/hero.jpg') center/cover no-repeat;
   position: relative;
-  border-bottom: 1px solid rgba(255,255,255,.08);
+  border-bottom: 1px solid rgba(0,0,0,.08);
 }
 .hero .overlay{
   position:absolute; inset:0;
-  background: linear-gradient(180deg, rgba(0,0,0,.55), rgba(0,0,0,.65));
+  background: linear-gradient(180deg, rgba(255,255,255,.6), rgba(255,255,255,.8));
   display:grid; place-items:center;
   text-align:center;
 }
 .hero-content{ padding: 6rem 0; }
 .hero p{ color: var(--muted); font-size: 1.1rem; }
-.btn{ display:inline-block; padding:.75rem 1rem; border-radius: 999px; border:1px solid rgba(255,255,255,.12); font-weight:600; }
+.btn{ display:inline-block; padding:.75rem 1rem; border-radius: 999px; border:1px solid rgba(0,0,0,.12); font-weight:600; }
 .btn:hover{ text-decoration:none; transform: translateY(-1px); }
 .btn:focus{ outline: 3px solid var(--ring); outline-offset: 2px; }
 .btn-primary{ background: var(--primary); color: var(--primary-ink); border-color: transparent; box-shadow: var(--shadow); }
@@ -82,13 +83,13 @@ p{ margin: 0 0 1rem; }
 
 /* Sections */
 .section{ padding: clamp(3rem, 6vw, 5rem) 0; }
-.section-alt{ background: radial-gradient(1200px 800px at 50% -10%, rgba(62,207,142,.08), transparent 60%), var(--bg-alt); }
+.section-alt{ background: radial-gradient(1200px 800px at 50% -10%, rgba(255,105,180,.08), transparent 60%), var(--bg-alt); }
 
 /* Grids & Cards */
 .grid-2{ display:grid; grid-template-columns: 1.2fr 1fr; gap:2rem; }
 .grid-3{ display:grid; grid-template-columns: repeat(3,1fr); gap:1.25rem; }
 .cards .card{
-  background: var(--surface); border:1px solid rgba(255,255,255,.06);
+  background: var(--surface); border:1px solid rgba(0,0,0,.06);
   border-radius: var(--radius); padding: 1.2rem; box-shadow: var(--shadow);
 }
 .cards .card.featured{ outline: 2px solid var(--primary); }
@@ -98,18 +99,18 @@ p{ margin: 0 0 1rem; }
 .checklist li{ margin:.3rem 0; }
 
 /* About */
-.about-photo img{ width:100%; border-radius: 12px; border:1px solid rgba(255,255,255,.08); display:block; }
+.about-photo img{ width:100%; border-radius: 12px; border:1px solid rgba(0,0,0,.08); display:block; }
 
 /* Calendar table */
-.table-wrap{ overflow-x:auto; border-radius: 12px; border:1px solid rgba(255,255,255,.08); }
+.table-wrap{ overflow-x:auto; border-radius: 12px; border:1px solid rgba(0,0,0,.08); }
 table.events{
   width:100%; border-collapse: collapse; background: var(--surface);
 }
 .events th, .events td{ padding:.9rem .8rem; text-align:left; }
 .events thead th{
-  font-size:.9rem; color:var(--muted); border-bottom:1px solid rgba(255,255,255,.08);
+  font-size:.9rem; color:var(--muted); border-bottom:1px solid rgba(0,0,0,.08);
 }
-.events tbody tr + tr td{ border-top:1px solid rgba(255,255,255,.06); }
+.events tbody tr + tr td{ border-top:1px solid rgba(0,0,0,.06); }
 
 /* Captains */
 .person img{ width:100%; height: 220px; object-fit: cover; border-radius: 10px; margin-bottom:.7rem; }
@@ -117,12 +118,12 @@ table.events{
 /* Donate */
 .donate-cta{
   display:flex; align-items:center; justify-content:space-between; gap:1rem;
-  background: linear-gradient(135deg, rgba(62,207,142,.15), rgba(62,207,142,.05));
-  border:1px solid rgba(62,207,142,.35); border-radius: var(--radius); padding:1.2rem 1.2rem;
+  background: linear-gradient(135deg, rgba(255,105,180,.15), rgba(255,105,180,.05));
+  border:1px solid rgba(255,105,180,.35); border-radius: var(--radius); padding:1.2rem 1.2rem;
 }
 
 /* Footer */
-.site-footer{ padding: 2rem 0; border-top:1px solid rgba(255,255,255,.08); background: #0a0b0d; }
+.site-footer{ padding: 2rem 0; border-top:1px solid rgba(0,0,0,.08); background: #f5f5f5; }
 .footer-inner{ display:flex; align-items:center; justify-content:space-between; }
 
 /* Skip link */
@@ -141,7 +142,7 @@ table.events{
 }
 @media (max-width: 680px){
   .grid-3{ grid-template-columns: 1fr; }
-  .site-nav{ display:none; position:absolute; right:1rem; top:64px; background: var(--surface); padding:.5rem; border-radius: 10px; border:1px solid rgba(255,255,255,.08); box-shadow: var(--shadow); }
+  .site-nav{ display:none; position:absolute; right:1rem; top:64px; background: var(--surface); padding:.5rem; border-radius: 10px; border:1px solid rgba(0,0,0,.08); box-shadow: var(--shadow); }
   .site-nav.open{ display:block; }
   .site-nav ul{ flex-direction: column; }
   .nav-toggle{ display:block; }
@@ -156,7 +157,7 @@ table.events{
   color:var(--primary-ink);
 }
 .badge-third{
-  background:rgba(255,255,255,.2);
+  background:rgba(0,0,0,.1);
   color:var(--text);
 }
 
@@ -166,7 +167,7 @@ table.events{
 .ride-form select{
   padding:.5rem;
   border-radius:8px;
-  border:1px solid rgba(255,255,255,.15);
+  border:1px solid rgba(0,0,0,.15);
   background:var(--surface);
   color:var(--text);
   margin-right:.5rem;
@@ -181,5 +182,5 @@ table.events{
   width:100%;
   border-radius:12px;
   margin-top:1rem;
-  border:1px solid rgba(255,255,255,.08);
+  border:1px solid rgba(0,0,0,.08);
 }


### PR DESCRIPTION
## Summary
- switch mock2 to a light, pride-themed palette
- add rainbow flag branding and inclusive hero message

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bfa85c7c83219cadb6811a89fad7