### PR TITLE
Add meta mockup builder for interactive layout editing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,7 @@
   <ul>
     <li><a href="mock1/">Mock 1</a></li>
     <li><a href="mock2/">Mock 2</a></li>
+      <li><a href="meta-mock/">Meta Mock Builder</a></li>
   </ul>
 </body>
 </html>

--- a/docs/meta-mock/index.html
+++ b/docs/meta-mock/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Meta Mockup Builder</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav id="menu">
+    <ul id="navList"></ul>
+    <div id="menuControls">
+      <input id="newMenuText" placeholder="New menu item" />
+      <button id="addMenuItem">Add</button>
+    </div>
+  </nav>
+  <div id="main">
+    <aside id="controls">
+      <section>
+        <h2>Tools</h2>
+        <div class="tool" draggable="true" data-type="header">Header</div>
+        <div class="tool" draggable="true" data-type="paragraph">Paragraph</div>
+        <div class="tool" draggable="true" data-type="image">Image</div>
+      </section>
+      <section>
+        <h2>Images</h2>
+        <div id="imagePicker">
+          <img src="../media/hero.jpg" alt="hero" />
+          <img src="../media/about.jpg" alt="about" />
+          <img src="../media/captain-delta.jpg" alt="delta" />
+        </div>
+      </section>
+      <section>
+        <h2>Palette</h2>
+        <label>Primary color <input type="color" id="primaryColor" value="#009688" /></label>
+      </section>
+      <section>
+        <button id="save">Save</button>
+        <button id="load">Load</button>
+        <button id="clear">Clear</button>
+      </section>
+    </aside>
+    <section id="canvas"></section>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/meta-mock/script.js
+++ b/docs/meta-mock/script.js
@@ -1,0 +1,144 @@
+const canvas = document.getElementById('canvas');
+const toolbox = document.getElementById('controls');
+const imagePicker = document.getElementById('imagePicker');
+let selectedImage = '../media/hero.jpg';
+let draggedSection = null;
+let draggedMenu = null;
+const navList = document.getElementById('navList');
+const primaryColor = document.getElementById('primaryColor');
+
+imagePicker.querySelectorAll('img').forEach(img => {
+  img.addEventListener('click', () => {
+    selectedImage = img.getAttribute('src');
+    imagePicker.querySelectorAll('img').forEach(i => i.classList.remove('selected'));
+    img.classList.add('selected');
+  });
+});
+
+// Drag from toolbox
+toolbox.addEventListener('dragstart', e => {
+  if (e.target.classList.contains('tool')) {
+    e.dataTransfer.setData('type', e.target.dataset.type);
+  }
+});
+
+canvas.addEventListener('dragover', e => e.preventDefault());
+canvas.addEventListener('drop', e => {
+  e.preventDefault();
+  const type = e.dataTransfer.getData('type');
+  if (type) {
+    let el;
+    if (type === 'header') {
+      el = document.createElement('h2');
+      el.textContent = 'Header';
+      el.contentEditable = true;
+    } else if (type === 'paragraph') {
+      el = document.createElement('p');
+      el.textContent = 'Your text';
+      el.contentEditable = true;
+    } else if (type === 'image') {
+      el = document.createElement('img');
+      el.src = selectedImage;
+    }
+    if (el) {
+      el.classList.add('section');
+      el.draggable = true;
+      canvas.appendChild(el);
+    }
+  } else if (draggedSection) {
+    if (e.target.classList.contains('section')) {
+      canvas.insertBefore(draggedSection, e.target.nextSibling);
+    } else {
+      canvas.appendChild(draggedSection);
+    }
+    draggedSection = null;
+  }
+});
+
+canvas.addEventListener('dragstart', e => {
+  if (e.target.classList.contains('section')) {
+    draggedSection = e.target;
+  }
+});
+
+// Menu item add and reorder
+function refreshMenuDraggables() {
+  navList.querySelectorAll('li').forEach(li => li.draggable = true);
+}
+refreshMenuDraggables();
+
+document.getElementById('addMenuItem').addEventListener('click', () => {
+  const text = document.getElementById('newMenuText').value.trim();
+  if (!text) return;
+  const li = document.createElement('li');
+  li.textContent = text;
+  li.contentEditable = true;
+  navList.appendChild(li);
+  document.getElementById('newMenuText').value = '';
+  refreshMenuDraggables();
+});
+
+navList.addEventListener('dragstart', e => {
+  if (e.target.tagName === 'LI') {
+    draggedMenu = e.target;
+  }
+});
+navList.addEventListener('dragover', e => e.preventDefault());
+navList.addEventListener('drop', e => {
+  e.preventDefault();
+  if (e.target.tagName === 'LI' && draggedMenu) {
+    navList.insertBefore(draggedMenu, e.target.nextSibling);
+  } else if (draggedMenu) {
+    navList.appendChild(draggedMenu);
+  }
+  draggedMenu = null;
+});
+
+// Color palette
+primaryColor.addEventListener('input', () => {
+  document.documentElement.style.setProperty('--primary', primaryColor.value);
+});
+
+// Save/Load/Clear
+function refreshSections() {
+  canvas.querySelectorAll('.section').forEach(sec => sec.draggable = true);
+}
+
+document.getElementById('save').addEventListener('click', () => {
+  const data = {
+    menu: navList.innerHTML,
+    content: canvas.innerHTML,
+    color: primaryColor.value
+  };
+  localStorage.setItem('metaMock', JSON.stringify(data));
+  alert('Saved');
+});
+
+document.getElementById('load').addEventListener('click', () => {
+  const raw = localStorage.getItem('metaMock');
+  if (!raw) return;
+  const data = JSON.parse(raw);
+  navList.innerHTML = data.menu || '';
+  canvas.innerHTML = data.content || '';
+  primaryColor.value = data.color || '#009688';
+  document.documentElement.style.setProperty('--primary', primaryColor.value);
+  refreshMenuDraggables();
+  refreshSections();
+});
+
+// auto load existing
+if (localStorage.getItem('metaMock')) {
+  const raw = localStorage.getItem('metaMock');
+  const data = JSON.parse(raw);
+  navList.innerHTML = data.menu || '';
+  canvas.innerHTML = data.content || '';
+  primaryColor.value = data.color || '#009688';
+  document.documentElement.style.setProperty('--primary', primaryColor.value);
+  refreshMenuDraggables();
+  refreshSections();
+}
+
+document.getElementById('clear').addEventListener('click', () => {
+  localStorage.removeItem('metaMock');
+  location.reload();
+});

--- a/docs/meta-mock/styles.css
+++ b/docs/meta-mock/styles.css
@@ -1,0 +1,71 @@
+:root {
+  --primary: #009688;
+}
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+#menu {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.5rem;
+}
+#menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+#menu li {
+  cursor: move;
+  padding: 0.25rem 0.5rem;
+  background: rgba(0,0,0,0.1);
+  border-radius: 4px;
+}
+#menuControls {
+  margin-top: 0.5rem;
+}
+#main {
+  display: flex;
+  height: calc(100vh - 100px);
+}
+#controls {
+  width: 200px;
+  padding: 1rem;
+  background: #f3f3f3;
+  overflow-y: auto;
+}
+#canvas {
+  flex: 1;
+  padding: 1rem;
+  border-left: 2px solid #ddd;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.tool {
+  padding: 0.25rem;
+  border: 1px solid #ccc;
+  margin-bottom: 0.5rem;
+  background: #fff;
+  cursor: grab;
+}
+#imagePicker img {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+#imagePicker img.selected {
+  border-color: var(--primary);
+}
+.section {
+  border: 1px dashed #ccc;
+  padding: 0.5rem;
+}
+.section img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add `meta-mock` mockup with drag-and-drop sections, editable menu, color palette picker, and localStorage save/load
- list `Meta Mock Builder` on docs index page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f0e908788321863f15c6323ef989